### PR TITLE
Delivery schema update

### DIFF
--- a/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
+++ b/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
@@ -17,6 +17,10 @@
                         <ApplicationIdentification>http://www.smpte-ra.org/schemas/2067-21/2016</ApplicationIdentification>
                     </ValueList>
                 </ApplicationIdentificationList>
+               <SegmentCardinality>
+                   <MinItem>1</MinItem>
+                   <MaxItem>1</MaxItem>
+               </SegmentCardinality>
                 <VirtualTrackList>
                     <ImageVirtualTrack>
                         <EssenceEncoding>J2K_4KIMF_SingleTileLossyProfile_M6S3</EssenceEncoding>
@@ -57,7 +61,7 @@
                             <FrameRate>30 1</FrameRate>
                         </FrameRateList>
                     </ImageVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -87,8 +91,8 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    </AudioVirtualTrack>
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -130,7 +134,7 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
+                    </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
@@ -182,8 +186,8 @@
                             <FrameRate>60000 1001</FrameRate>
                             <FrameRate>60 1</FrameRate>
                         </FrameRateList>
-                    </VirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    </ImageVirtualTrack>
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -213,8 +217,8 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    </AudioVirtualTrack>
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -256,7 +260,7 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
+                    </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
@@ -312,7 +316,7 @@
                             <FrameRate>30 1</FrameRate>
                         </FrameRateList>
                     </ImageVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -342,8 +346,8 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    </AudioVirtualTrack>
+                    <AudioVirtualTrack>
                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -385,8 +389,8 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </VirtualTrack>
-                </MultipleVirtualTrackList>
+                    </AudioVirtualTrack>
+                </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
         <Deliverable>
@@ -439,7 +443,7 @@
                             <FrameRate>60 1</FrameRate>
                         </FrameRateList>
                     </ImageVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -469,8 +473,8 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
-                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                    </AudioVirtualTrack>
+                    <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
@@ -512,7 +516,7 @@
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                    </MultipleVirtualTrack>
+                    </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>

--- a/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
+++ b/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
@@ -2,7 +2,7 @@
 <DeliverySpecificationList xmlns="http://www.imfug.com/ns/delivery-schema/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Id>urn:uuid:a0ce8ee4-c2b1-40eb-a14d-590429c3427d</Id>
     <AnnotationText>DRAFT Netflix Original Specification UHD/4K 3.0</AnnotationText>
-    <IssueDate>2018-01-27T00:00:00-00:00</IssueDate>
+    <IssueDate>2019-01-27T00:00:00-00:00</IssueDate>
     <Issuer>Netflix</Issuer>
     <Creator>Florian Schleich - fschleich@netflix.com</Creator>
     <DeliverableList>

--- a/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
+++ b/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<DeliverySpecificationList xmlns="http://www.imfug.com/ns/delivery-schema/2018">
-    <Id>urn:uuid:fb7cd4f5-5c6c-c3d6-593e-a1005d5b9d64</Id>
+<DeliverySpecificationList xmlns="http://www.imfug.com/ns/delivery-schema/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>urn:uuid:a0ce8ee4-c2b1-40eb-a14d-590429c3427d</Id>
     <AnnotationText>DRAFT Netflix Original Specification UHD/4K 3.0</AnnotationText>
-    <IssueDate>2018-05-30T16:10:06-00:00</IssueDate>
+    <IssueDate>2018-01-27T00:00:00-00:00</IssueDate>
     <Issuer>Netflix</Issuer>
     <Creator>Florian Schleich - fschleich@netflix.com</Creator>
     <DeliverableList>
@@ -18,9 +18,22 @@
                     </ValueList>
                 </ApplicationIdentificationList>
                 <VirtualTrackList>
-                    <VirtualTrack>
-                        <Kind>MainImageSequence</Kind>
+                    <ImageVirtualTrack>
                         <EssenceEncoding>J2K_4KIMF_SingleTileLossyProfile_M6S3</EssenceEncoding>
+                        <TimelineComplexity type="explicit">
+                            <Sequence>
+                                <Cardinality>
+                                    <MinItem>1</MinItem>
+                                    <MaxItem>1</MaxItem>
+                                </Cardinality>
+                                <Resource>
+                                    <Cardinality>
+                                        <MinItem>1</MinItem>
+                                        <MaxItem>1</MaxItem>
+                                    </Cardinality>
+                                </Resource>
+                            </Sequence>
+                        </TimelineComplexity>
                         <Colorimetry>COLOR.3</Colorimetry>
                         <Sampling>4:2:2</Sampling>
                         <Quantization>QE.1</Quantization>
@@ -43,6 +56,9 @@
                             <FrameRate>30000 1</FrameRate>
                             <FrameRate>30 1</FrameRate>
                         </FrameRateList>
+                    </ImageVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -57,24 +73,23 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sgLtRt</MCATagSymbol>
+							<MCATagSymbol>LtRt</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chLt</MCATagSymbol>
+                                <MCATagSymbol>Lt</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRt</MCATagSymbol>
+                                <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
+                    </MultipleVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -89,51 +104,33 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sg51</MCATagSymbol>
+							<MCATagSymbol>51</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chL</MCATagSymbol>
+                                <MCATagSymbol>L</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chR</MCATagSymbol>
+                                <MCATagSymbol>R</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chC</MCATagSymbol>
+                                <MCATagSymbol>C</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLFE</MCATagSymbol>
+                                <MCATagSymbol>LFE</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLs</MCATagSymbol>
+                                <MCATagSymbol>Ls</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRs</MCATagSymbol>
+                                <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                        <TimelineComplexity type="explicit">
-                            <Sequence>
-                                <Cardinality>
-                                    <MinItem>1</MinItem>
-                                    <MaxItem>1</MaxItem>
-                                </Cardinality>
-                                <Resource>
-                                    <Cardinality>
-                                        <MinItem>1</MinItem>
-                                        <MaxItem>1</MaxItem>
-                                    </Cardinality>
-                                </Resource>
-                            </Sequence>
-                        </TimelineComplexity>
-                    </VirtualTrack>
+                    </MultipleVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
@@ -149,10 +146,23 @@
                     </ValueList>
                 </ApplicationIdentificationList>
                 <VirtualTrackList>
-                    <VirtualTrack>
-                        <Kind>MainImageSequence</Kind>
+                    <ImageVirtualTrack>
                         <EssenceEncoding>J2K_4KIMF_SingleTileLossyProfile_M7S4</EssenceEncoding>
-                        <Colorimetry>COLOR.3</Colorimetry>
+                         <TimelineComplexity type="explicit">
+                            <Sequence>
+                                <Cardinality>
+                                    <MinItem>1</MinItem>
+                                    <MaxItem>1</MaxItem>
+                                </Cardinality>
+                                <Resource>
+                                    <Cardinality>
+                                        <MinItem>1</MinItem>
+                                        <MaxItem>1</MaxItem>
+                                    </Cardinality>
+                                </Resource>
+                            </Sequence>
+                        </TimelineComplexity>
+                       <Colorimetry>COLOR.3</Colorimetry>
                         <Sampling>4:2:2</Sampling>
                         <Quantization>QE.1</Quantization>
                         <FrameStructure>Progressive</FrameStructure>
@@ -172,6 +182,9 @@
                             <FrameRate>60000 1001</FrameRate>
                             <FrameRate>60 1</FrameRate>
                         </FrameRateList>
+                    </VirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -186,24 +199,23 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sgLtRt</MCATagSymbol>
+							<MCATagSymbol>LtRt</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chLt</MCATagSymbol>
+                                <MCATagSymbol>Lt</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRt</MCATagSymbol>
+                                <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
+                    </MultipleVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -218,51 +230,33 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sg51</MCATagSymbol>
+							<MCATagSymbol>51</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chL</MCATagSymbol>
+                                <MCATagSymbol>L</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chR</MCATagSymbol>
+                                <MCATagSymbol>R</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chC</MCATagSymbol>
+                                <MCATagSymbol>C</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLFE</MCATagSymbol>
+                                <MCATagSymbol>LFE</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLs</MCATagSymbol>
+                                <MCATagSymbol>Ls</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRs</MCATagSymbol>
+                                <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                        <TimelineComplexity type="explicit">
-                            <Sequence>
-                                <Cardinality>
-                                    <MinItem>1</MinItem>
-                                    <MaxItem>1</MaxItem>
-                                </Cardinality>
-                                <Resource>
-                                    <Cardinality>
-                                        <MinItem>1</MinItem>
-                                        <MaxItem>1</MaxItem>
-                                    </Cardinality>
-                                </Resource>
-                            </Sequence>
-                        </TimelineComplexity>
-                    </VirtualTrack>
+                    </MultipleVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
@@ -278,9 +272,22 @@
                     </ValueList>
                 </ApplicationIdentificationList>
                 <VirtualTrackList>
-                    <VirtualTrack>
-                        <Kind>MainImageSequence</Kind>
+                    <ImageVirtualTrack>
                         <EssenceEncoding>J2K_4KIMF_SingleTileLossyProfile_M6S3</EssenceEncoding>
+                        <TimelineComplexity type="explicit">
+                            <Sequence>
+                                <Cardinality>
+                                    <MinItem>1</MinItem>
+                                    <MaxItem>1</MaxItem>
+                                </Cardinality>
+                                <Resource>
+                                    <Cardinality>
+                                        <MinItem>1</MinItem>
+                                        <MaxItem>1</MaxItem>
+                                    </Cardinality>
+                                </Resource>
+                            </Sequence>
+                        </TimelineComplexity>
                         <Colorimetry>COLOR.3</Colorimetry>
                         <Sampling>4:4:4</Sampling>
                         <Quantization>QE.2</Quantization>
@@ -304,6 +311,9 @@
                             <FrameRate>30000 1</FrameRate>
                             <FrameRate>30 1</FrameRate>
                         </FrameRateList>
+                    </ImageVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -318,24 +328,23 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sgLtRt</MCATagSymbol>
+							<MCATagSymbol>LtRt</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chLt</MCATagSymbol>
+                                <MCATagSymbol>Lt</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRt</MCATagSymbol>
+                                <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
+                    </MultipleVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                       <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -350,52 +359,34 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
-                        <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sg51</MCATagSymbol>
+                       <SoundfieldGroupConfiguration>
+							<MCATagSymbol>51</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chL</MCATagSymbol>
+                                <MCATagSymbol>L</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chR</MCATagSymbol>
+                                <MCATagSymbol>R</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chC</MCATagSymbol>
+                                <MCATagSymbol>C</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLFE</MCATagSymbol>
+                                <MCATagSymbol>LFE</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLs</MCATagSymbol>
+                                <MCATagSymbol>Ls</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRs</MCATagSymbol>
+                                <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                        <TimelineComplexity type="explicit">
-                            <Sequence>
-                                <Cardinality>
-                                    <MinItem>1</MinItem>
-                                    <MaxItem>1</MaxItem>
-                                </Cardinality>
-                                <Resource>
-                                    <Cardinality>
-                                        <MinItem>1</MinItem>
-                                        <MaxItem>1</MaxItem>
-                                    </Cardinality>
-                                </Resource>
-                            </Sequence>
-                        </TimelineComplexity>
                     </VirtualTrack>
-                </VirtualTrackList>
+                </MultipleVirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>
         <Deliverable>
@@ -410,9 +401,22 @@
                     </ValueList>
                 </ApplicationIdentificationList>
                 <VirtualTrackList>
-                    <VirtualTrack>
-                        <Kind>MainImageSequence</Kind>
+                    <ImageVirtualTrack>
                         <EssenceEncoding>J2K_4KIMF_SingleTileLossyProfile_M7S4</EssenceEncoding>
+                        <TimelineComplexity type="explicit">
+                            <Sequence>
+                                <Cardinality>
+                                    <MinItem>1</MinItem>
+                                    <MaxItem>1</MaxItem>
+                                </Cardinality>
+                                <Resource>
+                                    <Cardinality>
+                                        <MinItem>1</MinItem>
+                                        <MaxItem>1</MaxItem>
+                                    </Cardinality>
+                                </Resource>
+                            </Sequence>
+                        </TimelineComplexity>
                         <Colorimetry>COLOR.3</Colorimetry>
                         <Sampling>4:4:4</Sampling>
                         <Quantization>QE.2</Quantization>
@@ -434,9 +438,9 @@
                             <FrameRate>60000 1</FrameRate>
                             <FrameRate>60 1</FrameRate>
                         </FrameRateList>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                    </ImageVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -451,24 +455,23 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sgLtRt</MCATagSymbol>
+							<MCATagSymbol>LtRt</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chLt</MCATagSymbol>
+                                <MCATagSymbol>Lt</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRt</MCATagSymbol>
+                                <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
+                    </MultipleVirtualTrack>
+                    <MultipleVirtualTrack xsi:type="AudioVirtualTrackType">
+                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
                         <TimelineComplexity type="explicit">
                             <Sequence>
                                 <Cardinality>
@@ -483,51 +486,33 @@
                                 </Resource>
                             </Sequence>
                         </TimelineComplexity>
-                    </VirtualTrack>
-                    <VirtualTrack>
-                        <Kind>MainAudioSequence</Kind>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>sg51</MCATagSymbol>
+							<MCATagSymbol>51</MCATagSymbol>
 						</SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
-                                <MCATagSymbol>chL</MCATagSymbol>
+                                <MCATagSymbol>L</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chR</MCATagSymbol>
+                                <MCATagSymbol>R</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chC</MCATagSymbol>
+                                <MCATagSymbol>C</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLFE</MCATagSymbol>
+                                <MCATagSymbol>LFE</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chLs</MCATagSymbol>
+                                <MCATagSymbol>Ls</MCATagSymbol>
                             </AudioChannel>
                             <AudioChannel>
-                                <MCATagSymbol>chRs</MCATagSymbol>
+                                <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
 						<SampleRateList>
 							<SampleRate>48000 1</SampleRate>
 						</SampleRateList>
-                        <TimelineComplexity type="explicit">
-                            <Sequence>
-                                <Cardinality>
-                                    <MinItem>1</MinItem>
-                                    <MaxItem>1</MaxItem>
-                                </Cardinality>
-                                <Resource>
-                                    <Cardinality>
-                                        <MinItem>1</MinItem>
-                                        <MaxItem>1</MaxItem>
-                                    </Cardinality>
-                                </Resource>
-                            </Sequence>
-                        </TimelineComplexity>
-                    </VirtualTrack>
+                    </MultipleVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
         </Deliverable>

--- a/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
+++ b/examples/Netflix/DRAFT_Netflix_OriginalsSpec_3.0_UHD_4K_SDR.xml
@@ -42,7 +42,7 @@
                         <Sampling>4:2:2</Sampling>
                         <Quantization>QE.1</Quantization>
                         <FrameStructure>Progressive</FrameStructure>
-						<Stereoscopy>Monoscopic</Stereoscopy>
+                        <Stereoscopy>Monoscopic</Stereoscopy>
                         <ColorComponents>YCbCr</ColorComponents>
                         <PixelBitDepthList>
                             <PixelBitDepth>10</PixelBitDepth>
@@ -78,8 +78,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>LtRt</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>LtRt</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>Lt</MCATagSymbol>
@@ -88,9 +88,9 @@
                                 <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                     <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
@@ -109,8 +109,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>51</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>51</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>L</MCATagSymbol>
@@ -131,9 +131,9 @@
                                 <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
@@ -170,7 +170,7 @@
                         <Sampling>4:2:2</Sampling>
                         <Quantization>QE.1</Quantization>
                         <FrameStructure>Progressive</FrameStructure>
-						<Stereoscopy>Monoscopic</Stereoscopy>
+                        <Stereoscopy>Monoscopic</Stereoscopy>
                         <ColorComponents>YCbCr</ColorComponents>
                         <PixelBitDepthList>
                             <PixelBitDepth>10</PixelBitDepth>
@@ -204,8 +204,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>LtRt</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>LtRt</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>Lt</MCATagSymbol>
@@ -214,9 +214,9 @@
                                 <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                     <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
@@ -235,8 +235,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>51</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>51</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>L</MCATagSymbol>
@@ -257,9 +257,9 @@
                                 <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
@@ -296,7 +296,7 @@
                         <Sampling>4:4:4</Sampling>
                         <Quantization>QE.2</Quantization>
                         <FrameStructure>Progressive</FrameStructure>
-						<Stereoscopy>Monoscopic</Stereoscopy>
+                        <Stereoscopy>Monoscopic</Stereoscopy>
                         <ColorComponents>RGB</ColorComponents>
                         <PixelBitDepthList>
                             <PixelBitDepth>10</PixelBitDepth>
@@ -333,8 +333,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>LtRt</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>LtRt</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>Lt</MCATagSymbol>
@@ -343,9 +343,9 @@
                                 <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                     <AudioVirtualTrack>
                        <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
@@ -364,8 +364,8 @@
                             </Sequence>
                         </TimelineComplexity>
                        <SoundfieldGroupConfiguration>
-							<MCATagSymbol>51</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>51</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>L</MCATagSymbol>
@@ -386,9 +386,9 @@
                                 <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>
@@ -425,7 +425,7 @@
                         <Sampling>4:4:4</Sampling>
                         <Quantization>QE.2</Quantization>
                         <FrameStructure>Progressive</FrameStructure>
-						<Stereoscopy>Monoscopic</Stereoscopy>
+                        <Stereoscopy>Monoscopic</Stereoscopy>
                         <ColorComponents>RGB</ColorComponents>
                         <PixelBitDepthList>
                             <PixelBitDepth>10</PixelBitDepth>
@@ -460,8 +460,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>LtRt</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>LtRt</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>Lt</MCATagSymbol>
@@ -470,9 +470,9 @@
                                 <MCATagSymbol>Rt</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                     <AudioVirtualTrack>
                         <EssenceEncoding>MXFGCClipWrappedBroadcastWaveAudioData</EssenceEncoding>
@@ -491,8 +491,8 @@
                             </Sequence>
                         </TimelineComplexity>
                         <SoundfieldGroupConfiguration>
-							<MCATagSymbol>51</MCATagSymbol>
-						</SoundfieldGroupConfiguration>
+                            <MCATagSymbol>51</MCATagSymbol>
+                        </SoundfieldGroupConfiguration>
                         <AudioChannelMapping>
                             <AudioChannel>
                                 <MCATagSymbol>L</MCATagSymbol>
@@ -513,9 +513,9 @@
                                 <MCATagSymbol>Rs</MCATagSymbol>
                             </AudioChannel>
                         </AudioChannelMapping>
-						<SampleRateList>
-							<SampleRate>48000 1</SampleRate>
-						</SampleRateList>
+                        <SampleRateList>
+                            <SampleRate>48000 1</SampleRate>
+                        </SampleRateList>
                     </AudioVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>

--- a/schema/IMF_DeliverySchema.xsd
+++ b/schema/IMF_DeliverySchema.xsd
@@ -1,256 +1,325 @@
 <?xml version="1.0"?>
 <!-- probably need a version in the targetNamespace? -->
-<xs:schema targetNamespace="http://www.imfug.com/ns/delivery-schema/2018"
-    xmlns:dsl="http://www.imfug.com/ns/delivery-schema/2018"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:dcml="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/"
-    elementFormDefault="qualified" attributeFormDefault="unqualified">
-<xs:import namespace="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/"/>    
-<xs:element name="DeliverySpecificationList">
-    <xs:complexType>
-        <xs:sequence>
-            <xs:element name="Id" type="dcml:UUIDType"/>
-            <xs:element name="AnnotationText" type="dcml:UserTextType" minOccurs="0"/>
-            <xs:element name="IssueDate" type="xs:dateTime"/>
-            <xs:element name="Issuer" type="dcml:UserTextType" minOccurs="0"/>
-            <xs:element name="Creator" type="dcml:UserTextType" minOccurs="0"/>
-            <xs:element name="DeliverableList">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="Deliverable" minOccurs="1" maxOccurs="unbounded" type="dsl:DeliverableType"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>            
-</xs:element>
-         
-<xs:complexType name="DeliverableType">
-    <xs:sequence>
-        <xs:element name="Id" type="dcml:UUIDType"/>
-            <xs:element name="Label">
-                <xs:simpleType>
-                    <xs:restriction base="xs:string"/>
-                </xs:simpleType>
-            </xs:element>
-        <xs:element name="CompositionPlaylistConstraints">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="OwnerId" type="xs:anyURI"/>
-                    <xs:element name="ApplicationIdentificationList" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="MatchType">
-                                    <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                            <xs:pattern value="exclusive|inclusive"/>
-                                        </xs:restriction>
-                                    </xs:simpleType>
-                                </xs:element>
-                                <xs:element name="ValueList">
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:element name="ApplicationIdentification" type="xs:anyURI"
-                                                minOccurs="1" maxOccurs="unbounded"/>
-                                        </xs:sequence>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="0"/>
-                    <xs:element name="VirtualTrackList">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="VirtualTrack" type="dsl:VirtualTrackType"
-                                    minOccurs="1" maxOccurs="unbounded"/>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-    </xs:sequence>
-</xs:complexType>
-        
-<xs:complexType name="VirtualTrackType">
-    <xs:sequence>
-        <xs:element name="Kind" type="dcml:UserTextType"/>            	
-        <xs:element name="SoundfieldGroupConfiguration" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                     <xs:element name="MCATagSymbol">
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:pattern value="sg[0-9A-Z][0-9a-zA-Z]+"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:element>
-                </xs:sequence>   
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="AudioChannelMapping" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="AudioChannel" minOccurs="1" maxOccurs="unbounded">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="MCATagSymbol">
-                                    <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                            <xs:pattern value="ch[A-Z][0-9a-zA-Z]*"/>
-                                        </xs:restriction>
-                                    </xs:simpleType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="EssenceEncoding" type="xs:string"/>
-
-<!-- prototype: essence encoding constraints -->
-        <xs:element name="EssenceEncodingConstraintList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="EssenceEncodingConstraint" minOccurs="0" maxOccurs="unbounded">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Name" type="xs:string"/>
-                                <xs:element name="PropertyList">
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:element name="Property" maxOccurs="unbounded">
-                                                <xs:complexType>
-                                                    <xs:sequence>
-                                                        <xs:element name="Name" type="xs:string"/>
-                                                        <xs:element name="value" type="xs:string"/>
-                                                    </xs:sequence>
-                                                </xs:complexType>
-                                            </xs:element>
-                                        </xs:sequence>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
-                <xs:attribute name="scope" type="xs:anyURI" use="required"/>
-            </xs:complexType>        
-        </xs:element>
-<!-- prototype: essence encoding constraints -->
-
-        <xs:element name="Colorimetry" type="xs:string" minOccurs="0"/>
-        <xs:element name="Sampling" type="xs:string" minOccurs="0"/>
-        <xs:element name="Quantization" type="xs:string" minOccurs="0"/>
-        <xs:element name="FrameStructure" type="xs:string" minOccurs="0"/>
-        <xs:element name="Stereoscopy" type="xs:string" minOccurs="0"/>
-        <xs:element name="ColorComponents" minOccurs="0">
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:pattern value="YCbCr|RGB|XYZ" />
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:element>
-        <xs:element name="PixelBitDepthList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="PixelBitDepth" minOccurs="0" maxOccurs="unbounded" type="xs:integer"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="ImageFrameWidthList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="ImageFrameWidth" minOccurs="0" maxOccurs="unbounded" type="xs:integer"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="ImageFrameHeightList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="ImageFrameHeight" minOccurs="0" maxOccurs="unbounded" type="xs:integer"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="FrameRateList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="FrameRate" minOccurs="0" maxOccurs="unbounded" type="dcml:RationalType"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="SampleRateList" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="SampleRate" type="dcml:RationalType" maxOccurs="unbounded"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="TimelineComplexity" minOccurs="0" maxOccurs="2">
-            <xs:complexType>
-                <xs:sequence>
-                    <xs:element name="SequenceCardinality" type="dsl:CardinalityType" minOccurs="0">
-                        <!-- tbd -->
-            	    </xs:element>
-                    <xs:element name="ResourceCardinality" type="dsl:CardinalityType" minOccurs="0">
-                        <!-- tbd -->
-                    </xs:element>        
-                    <xs:element name="Sequence">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Cardinality" type="dsl:CardinalityType"
-                                    minOccurs="0" maxOccurs="1"/>
-                                <xs:element name="Resource">
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:element name="Cardinality" type="dsl:CardinalityType"
-                                                minOccurs="0" maxOccurs="1"/>
-                                        </xs:sequence>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
-                <xs:attribute name="type" use="required">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:pattern value="general|explicit" />
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:complexType>
-        </xs:element>
-        <xs:element name="ReferenceCardinality" minOccurs="0">
-            <xs:complexType>
-                <xs:sequence>
-            	    <xs:element name="Sequence" type="dsl:CardinalityType"/>
-                </xs:sequence>
-            </xs:complexType>
-        </xs:element>
-    </xs:sequence>
-            
-    <xs:attribute name="namespace">
-        <xs:simpleType>
-            <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-    </xs:attribute>
-</xs:complexType>
-            
-<xs:complexType name="CardinalityType">
-    <xs:sequence>
-         <xs:element name="MinItem">
-             <xs:simpleType>
-                 <xs:restriction base="xs:integer"/>
-             </xs:simpleType>
-         </xs:element>
-         <xs:element name="MaxItem">
-             <xs:simpleType>
-                 <xs:restriction base="xs:integer"/>
-             </xs:simpleType>
-         </xs:element>
-    </xs:sequence>
-</xs:complexType>
+<xs:schema xmlns:dsl="http://www.imfug.com/ns/delivery-schema/2019" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcml="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/" targetNamespace="http://www.imfug.com/ns/delivery-schema/2019" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/" schemaLocation="dcmlTypes.xsd"/>
+	<xs:element name="DeliverySpecificationList">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Id" type="dcml:UUIDType"/>
+				<xs:element name="AnnotationText" type="dcml:UserTextType" minOccurs="0"/>
+				<xs:element name="IssueDate" type="xs:dateTime"/>
+				<xs:element name="Issuer" type="dcml:UserTextType" minOccurs="0"/>
+				<xs:element name="Creator" type="dcml:UserTextType" minOccurs="0"/>
+				<xs:element name="DeliverableList">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Deliverable" type="dsl:DeliverableType" minOccurs="1" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="DeliverableType">
+		<xs:sequence>
+			<xs:element name="Id" type="dcml:UUIDType"/>
+			<xs:element name="Label">
+				<xs:simpleType>
+					<xs:restriction base="xs:string"/>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CompositionPlaylistConstraints">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="OwnerId" type="xs:anyURI"/>
+						<xs:element name="ApplicationIdentificationList" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="MatchType">
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:pattern value="exclusive|inclusive"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ValueList">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="1" maxOccurs="unbounded"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="0"/>
+						<xs:element name="VirtualTrackList">
+							<xs:complexType>
+								<xs:sequence>
+									<!-- List all Virtual tracks with maxOccurs=1 individually -->
+									<xs:element name="ImageVirtualTrack" type="dsl:ImageVirtualTrackType" minOccurs="0" maxOccurs="1"/>
+									<xs:element name="MultipleVirtualTrack" type="dsl:MultipleVirtualTrackType" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- - -->
+	<!-- Abstract base class containing all common properties for a VirtualTrack -->
+	<xs:complexType name="GenericVirtualTrackType" abstract="true">
+		<xs:sequence>
+			<xs:element name="EssenceEncoding" type="xs:string"/>
+			<!-- prototype: essence encoding constraints -->
+			<xs:element name="EssenceEncodingConstraintList" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="EssenceEncodingConstraint" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Name" type="xs:string"/>
+									<xs:element name="PropertyList">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Property" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="Name" type="xs:string"/>
+															<xs:element name="value" type="xs:string"/>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="scope" type="xs:anyURI" use="required"/>
+				</xs:complexType>
+			</xs:element>
+			<!-- prototype: essence encoding constraints -->
+			<xs:element name="TimelineComplexity" minOccurs="0" maxOccurs="2">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SequenceCardinality" type="dsl:CardinalityType" minOccurs="0">
+							<!-- tbd -->
+						</xs:element>
+						<xs:element name="ResourceCardinality" type="dsl:CardinalityType" minOccurs="0">
+							<!-- tbd -->
+						</xs:element>
+						<xs:element name="Sequence">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
+									<xs:element name="Resource">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="type" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="general|explicit"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ReferenceCardinality" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Sequence" type="dsl:CardinalityType"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="namespace">
+			<xs:simpleType>
+				<xs:restriction base="xs:string"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<!-- - -->
+	<!-- Abstract base class containing all common properties for a SingleVirtualTrack -->
+	<xs:complexType name="SingleVirtualTrackType" abstract="true">
+		<xs:complexContent>
+	<xs:extension base="dsl:GenericVirtualTrackType">	
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- - -->
+	<!-- Abstract base class containing all common properties for a MultipleVirtualTrack -->
+	<xs:complexType name="MultipleVirtualTrackType" abstract="true">
+		<xs:complexContent>
+	<xs:extension base="dsl:GenericVirtualTrackType">	
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- - -->
+	<!-- AudioVirtualTrack extends the MultipleVirtualTrack-->
+	<xs:complexType name="AudioVirtualTrackType">
+		<xs:complexContent>
+			<xs:extension base="dsl:MultipleVirtualTrackType">
+				<xs:sequence>
+					<xs:element name="SoundfieldGroupConfiguration" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="MCATagSymbol">
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<!-- As defined in ST2067-8 and ST428-12-->
+											<xs:pattern value="ST|DM|DNS|30|40|50|60|70|LtRt|51EX|HA|VA|51|71|SDS|61|M"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="AudioChannelMapping" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="AudioChannel" minOccurs="1" maxOccurs="unbounded">
+									<xs:complexType>
+										<xs:sequence>
+											<xs:element name="MCATagSymbol">
+												<xs:simpleType>
+													<xs:restriction base="xs:string">
+														<!-- As defined in ST2067-8 and ST428-12-->
+														<xs:pattern value="M1|M2|Lt|Rt|Lst|Rst|S|NSC[0-9]{3}|L|R|C|LFE|Ls|Rs|Lss|Rss|Lrs|Rrs|Lc|Rc|Cs|HI|VIN"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:element>
+										</xs:sequence>
+									</xs:complexType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="SampleRateList" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="SampleRate" maxOccurs="unbounded">
+									<xs:simpleType>
+										<xs:restriction base="dcml:RationalType">
+											<xs:pattern value="48000 1|96000 1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- - -->
+	<!-- ImageVirtualTrack extends the SingleVirtualTrack-->
+	<xs:complexType name="ImageVirtualTrackType">
+		<xs:complexContent>
+			<xs:extension base="dsl:SingleVirtualTrackType">
+				<xs:sequence>
+					<xs:element name="Colorimetry" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="COLOR.1|COLOR.2|COLOR.3|COLOR.4|COLOR.5|COLOR.6|COLOR.7|COLOR.APP5.AP0"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="Sampling" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="4:2:2|4:4:4"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="Quantization" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="QE.1|QE.2"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="FrameStructure" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="Interlaced|Progressive"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="Stereoscopy" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="Monoscopic|Stereoscopic"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="ColorComponents" minOccurs="0">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:pattern value="YCbCr|RGB|XYZ"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="PixelBitDepthList" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="PixelBitDepth" minOccurs="0" maxOccurs="unbounded">
+									<xs:simpleType>
+										<xs:restriction base="xs:integer">
+											<xs:pattern value="8|10|12|16"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="ImageFrameWidthList" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="ImageFrameWidth" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="ImageFrameHeightList" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="ImageFrameHeight" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="FrameRateList" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="FrameRate" type="dcml:RationalType" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CardinalityType">
+		<xs:sequence>
+			<xs:element name="MinItem">
+				<xs:simpleType>
+					<xs:restriction base="xs:integer"/>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="MaxItem">
+				<xs:simpleType>
+					<xs:restriction base="xs:integer"/>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/schema/IMF_DeliverySchema.xsd
+++ b/schema/IMF_DeliverySchema.xsd
@@ -1,311 +1,311 @@
 <?xml version="1.0"?>
 <!-- probably need a version in the targetNamespace? -->
 <xs:schema xmlns:dsl="http://www.imfug.com/ns/delivery-schema/2019" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcml="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/" targetNamespace="http://www.imfug.com/ns/delivery-schema/2019" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:import namespace="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/" schemaLocation="dcmlTypes.xsd"/>
-	<xs:element name="DeliverySpecificationList">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="Id" type="dcml:UUIDType"/>
-				<xs:element name="AnnotationText" type="dcml:UserTextType" minOccurs="0"/>
-				<xs:element name="IssueDate" type="xs:dateTime"/>
-				<xs:element name="Issuer" type="dcml:UserTextType" minOccurs="0"/>
-				<xs:element name="Creator" type="dcml:UserTextType" minOccurs="0"/>
-				<xs:element name="DeliverableList">
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="Deliverable" type="dsl:DeliverableType" minOccurs="1" maxOccurs="unbounded"/>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:complexType name="DeliverableType">
-		<xs:sequence>
-			<xs:element name="Id" type="dcml:UUIDType"/>
-			<xs:element name="Label">
-				<xs:simpleType>
-					<xs:restriction base="xs:string"/>
-				</xs:simpleType>
-			</xs:element>
-			<xs:element name="CompositionPlaylistConstraints">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="OwnerId" type="xs:anyURI"/>
-						<xs:element name="ApplicationIdentificationList" minOccurs="0">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="MatchType">
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:pattern value="exclusive|inclusive"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
-									<xs:element name="ValueList">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="1" maxOccurs="unbounded"/>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="0"/>
-						<xs:element name="SegmentCardinality" type="dsl:CardinalityType" minOccurs="0">
-						</xs:element>
-						<xs:element name="VirtualTrackList">
-							<xs:complexType>
-								<xs:sequence>
-									<!-- List all Virtual tracks with maxOccurs=1 individually -->
-									<xs:element name="ImageVirtualTrack" type="dsl:ImageVirtualTrackType" minOccurs="0" maxOccurs="1"/>
-									<xs:element name="AudioVirtualTrack" type="dsl:AudioVirtualTrackType" minOccurs="0" maxOccurs="unbounded"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<!-- - -->
-	<!-- Abstract base class containing all common properties for a VirtualTrack -->
-	<xs:complexType name="GenericVirtualTrackType" abstract="true">
-		<xs:sequence>
-			<xs:element name="EssenceEncoding" type="xs:string"/>
-			<!-- prototype: essence encoding constraints -->
-			<xs:element name="EssenceEncodingConstraintList" minOccurs="0">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="EssenceEncodingConstraint" minOccurs="0" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="Name" type="xs:string"/>
-									<xs:element name="PropertyList">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="Property" maxOccurs="unbounded">
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="Name" type="xs:string"/>
-															<xs:element name="value" type="xs:string"/>
-														</xs:sequence>
-													</xs:complexType>
-												</xs:element>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-					<xs:attribute name="scope" type="xs:anyURI" use="required"/>
-				</xs:complexType>
-			</xs:element>
-			<!-- prototype: essence encoding constraints (deprecated - to be reconsidered)-->
-			<xs:element name="TimelineComplexity" minOccurs="0" maxOccurs="2">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="SequenceCardinality" type="dsl:CardinalityType" minOccurs="0">
-							<!-- tbd -->
-						</xs:element>
-						<xs:element name="ResourceCardinality" type="dsl:CardinalityType" minOccurs="0">
-							<!-- tbd -->
-						</xs:element>
-						<xs:element name="Sequence">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
-									<xs:element name="Resource">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-					<xs:attribute name="type" use="required">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="general|explicit"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="ReferenceCardinality" minOccurs="0">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="Sequence" type="dsl:CardinalityType"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-		<xs:attribute name="namespace">
-			<xs:simpleType>
-				<xs:restriction base="xs:string"/>
-			</xs:simpleType>
-		</xs:attribute>
-	</xs:complexType>
-	<!-- - -->
-	<!-- AudioVirtualTrack extends the GenericVirtualTrackType-->
-	<xs:complexType name="AudioVirtualTrackType">
-		<xs:complexContent>
-			<xs:extension base="dsl:GenericVirtualTrackType">
-				<xs:sequence>
-					<xs:element name="SoundfieldGroupConfiguration" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="MCATagSymbol">
-									<xs:simpleType>
-										<xs:restriction base="xs:string">
-											<!-- As defined in ST2067-8 and ST428-12-->
-											<xs:pattern value="ST|DM|DNS|30|40|50|60|70|LtRt|51EX|HA|VA|51|71|SDS|61|M"/>
-										</xs:restriction>
-									</xs:simpleType>
-								</xs:element>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="AudioChannelMapping" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="AudioChannel" minOccurs="1" maxOccurs="unbounded">
-									<xs:complexType>
-										<xs:sequence>
-											<xs:element name="MCATagSymbol">
-												<xs:simpleType>
-													<xs:restriction base="xs:string">
-														<!-- As defined in ST2067-8 and ST428-12-->
-														<xs:pattern value="M1|M2|Lt|Rt|Lst|Rst|S|NSC[0-9]{3}|L|R|C|LFE|Ls|Rs|Lss|Rss|Lrs|Rrs|Lc|Rc|Cs|HI|VIN"/>
-													</xs:restriction>
-												</xs:simpleType>
-											</xs:element>
-										</xs:sequence>
-									</xs:complexType>
-								</xs:element>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="SampleRateList" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="SampleRate" maxOccurs="unbounded">
-									<xs:simpleType>
-										<xs:restriction base="dcml:RationalType">
-											<xs:pattern value="48000 1|96000 1"/>
-										</xs:restriction>
-									</xs:simpleType>
-								</xs:element>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- - -->
-	<!-- ImageVirtualTrack extends the SingleVirtualTrack-->
-	<xs:complexType name="ImageVirtualTrackType">
-		<xs:complexContent>
-			<xs:extension base="dsl:GenericVirtualTrackType">
-				<xs:sequence>
-					<xs:element name="Colorimetry" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="COLOR.1|COLOR.2|COLOR.3|COLOR.4|COLOR.5|COLOR.6|COLOR.7|COLOR.APP5.AP0"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="Sampling" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="4:2:2|4:4:4"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="Quantization" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="QE.1|QE.2"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="FrameStructure" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="Interlaced|Progressive"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="Stereoscopy" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="Monoscopic|Stereoscopic"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="ColorComponents" minOccurs="0">
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:pattern value="YCbCr|RGB|XYZ"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:element>
-					<xs:element name="PixelBitDepthList" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="PixelBitDepth" minOccurs="0" maxOccurs="unbounded">
-									<xs:simpleType>
-										<xs:restriction base="xs:integer">
-											<xs:pattern value="8|10|12|16"/>
-										</xs:restriction>
-									</xs:simpleType>
-								</xs:element>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="ImageFrameWidthList" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="ImageFrameWidth" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="ImageFrameHeightList" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="ImageFrameHeight" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="FrameRateList" minOccurs="0">
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="FrameRate" type="dcml:RationalType" minOccurs="0" maxOccurs="unbounded"/>
-							</xs:sequence>
-						</xs:complexType>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<xs:complexType name="CardinalityType">
-		<xs:sequence>
-			<xs:element name="MinItem">
-				<xs:simpleType>
-					<xs:restriction base="xs:integer"/>
-				</xs:simpleType>
-			</xs:element>
-			<xs:element name="MaxItem">
-				<xs:simpleType>
-					<xs:restriction base="xs:integer"/>
-				</xs:simpleType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
+    <xs:import namespace="http://www.smpte-ra.org/schemas/433/2008/dcmlTypes/" schemaLocation="dcmlTypes.xsd"/>
+    <xs:element name="DeliverySpecificationList">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="Id" type="dcml:UUIDType"/>
+                <xs:element name="AnnotationText" type="dcml:UserTextType" minOccurs="0"/>
+                <xs:element name="IssueDate" type="xs:dateTime"/>
+                <xs:element name="Issuer" type="dcml:UserTextType" minOccurs="0"/>
+                <xs:element name="Creator" type="dcml:UserTextType" minOccurs="0"/>
+                <xs:element name="DeliverableList">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Deliverable" type="dsl:DeliverableType" minOccurs="1" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="DeliverableType">
+        <xs:sequence>
+            <xs:element name="Id" type="dcml:UUIDType"/>
+            <xs:element name="Label">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"/>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="CompositionPlaylistConstraints">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="OwnerId" type="xs:anyURI"/>
+                        <xs:element name="ApplicationIdentificationList" minOccurs="0">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="MatchType">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:pattern value="exclusive|inclusive"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="ValueList">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="1" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="0"/>
+                        <xs:element name="SegmentCardinality" type="dsl:CardinalityType" minOccurs="0">
+                        </xs:element>
+                        <xs:element name="VirtualTrackList">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="ImageVirtualTrack" type="dsl:ImageVirtualTrackType" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="AudioVirtualTrack" type="dsl:AudioVirtualTrackType" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <!-- - -->
+    <!-- Abstract base class containing all common properties for a VirtualTrack -->
+    <xs:complexType name="GenericVirtualTrackType" abstract="true">
+        <xs:sequence>
+            <xs:element name="EssenceEncoding" type="xs:string"/>
+            <!-- prototype: essence encoding constraints -->
+            <xs:element name="EssenceEncodingConstraintList" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="EssenceEncodingConstraint" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Name" type="xs:string"/>
+                                    <xs:element name="PropertyList">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="Property" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Name" type="xs:string"/>
+                                                            <xs:element name="value" type="xs:string"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="scope" type="xs:anyURI" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <!-- prototype: essence encoding constraints -->
+            <!-- TimelineComplexity on Virtual Track level is marked deprecated - to be reconsidered -->
+            <xs:element name="TimelineComplexity" minOccurs="0" maxOccurs="2">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="SequenceCardinality" type="dsl:CardinalityType" minOccurs="0">
+                            <!-- tbd -->
+                        </xs:element>
+                        <xs:element name="ResourceCardinality" type="dsl:CardinalityType" minOccurs="0">
+                            <!-- tbd -->
+                        </xs:element>
+                        <xs:element name="Sequence">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="Resource">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="Cardinality" type="dsl:CardinalityType" minOccurs="0" maxOccurs="1"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="type" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="general|explicit"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ReferenceCardinality" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Sequence" type="dsl:CardinalityType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="namespace">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <!-- - -->
+    <!-- AudioVirtualTrack extends the GenericVirtualTrackType-->
+    <xs:complexType name="AudioVirtualTrackType">
+        <xs:complexContent>
+            <xs:extension base="dsl:GenericVirtualTrackType">
+                <xs:sequence>
+                    <xs:element name="SoundfieldGroupConfiguration" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="MCATagSymbol">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                            <!-- As defined in ST2067-8 and ST428-12-->
+                                            <xs:pattern value="ST|DM|DNS|30|40|50|60|70|LtRt|51EX|HA|VA|51|71|SDS|61|M"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="AudioChannelMapping" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="AudioChannel" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:element name="MCATagSymbol">
+                                                <xs:simpleType>
+                                                    <xs:restriction base="xs:string">
+                                                        <!-- As defined in ST2067-8 and ST428-12-->
+                                                        <xs:pattern value="M1|M2|Lt|Rt|Lst|Rst|S|NSC[0-9]{3}|L|R|C|LFE|Ls|Rs|Lss|Rss|Lrs|Rrs|Lc|Rc|Cs|HI|VIN"/>
+                                                    </xs:restriction>
+                                                </xs:simpleType>
+                                            </xs:element>
+                                        </xs:sequence>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="SampleRateList" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="SampleRate" maxOccurs="unbounded">
+                                    <xs:simpleType>
+                                        <xs:restriction base="dcml:RationalType">
+                                            <xs:pattern value="48000 1|96000 1"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!-- - -->
+    <!-- ImageVirtualTrack extends the SingleVirtualTrack-->
+    <xs:complexType name="ImageVirtualTrackType">
+        <xs:complexContent>
+            <xs:extension base="dsl:GenericVirtualTrackType">
+                <xs:sequence>
+                    <xs:element name="Colorimetry" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="COLOR.1|COLOR.2|COLOR.3|COLOR.4|COLOR.5|COLOR.6|COLOR.7|COLOR.APP5.AP0"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="Sampling" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="4:2:2|4:4:4"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="Quantization" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="QE.1|QE.2"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="FrameStructure" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="Interlaced|Progressive"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="Stereoscopy" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="Monoscopic|Stereoscopic"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="ColorComponents" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:pattern value="YCbCr|RGB|XYZ"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="PixelBitDepthList" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="PixelBitDepth" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:integer">
+                                            <xs:pattern value="8|10|12|16"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="ImageFrameWidthList" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="ImageFrameWidth" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="ImageFrameHeightList" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="ImageFrameHeight" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="FrameRateList" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="FrameRate" type="dcml:RationalType" minOccurs="0" maxOccurs="unbounded"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="CardinalityType">
+        <xs:sequence>
+            <xs:element name="MinItem">
+                <xs:simpleType>
+                    <xs:restriction base="xs:integer"/>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="MaxItem">
+                <xs:simpleType>
+                    <xs:restriction base="xs:integer"/>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
 </xs:schema>

--- a/schema/IMF_DeliverySchema.xsd
+++ b/schema/IMF_DeliverySchema.xsd
@@ -53,12 +53,14 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="ApplicationIdentification" type="xs:anyURI" minOccurs="0"/>
+						<xs:element name="SegmentCardinality" type="dsl:CardinalityType" minOccurs="0">
+						</xs:element>
 						<xs:element name="VirtualTrackList">
 							<xs:complexType>
 								<xs:sequence>
 									<!-- List all Virtual tracks with maxOccurs=1 individually -->
 									<xs:element name="ImageVirtualTrack" type="dsl:ImageVirtualTrackType" minOccurs="0" maxOccurs="1"/>
-									<xs:element name="MultipleVirtualTrack" type="dsl:MultipleVirtualTrackType" minOccurs="0" maxOccurs="unbounded"/>
+									<xs:element name="AudioVirtualTrack" type="dsl:AudioVirtualTrackType" minOccurs="0" maxOccurs="unbounded"/>
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
@@ -101,7 +103,7 @@
 					<xs:attribute name="scope" type="xs:anyURI" use="required"/>
 				</xs:complexType>
 			</xs:element>
-			<!-- prototype: essence encoding constraints -->
+			<!-- prototype: essence encoding constraints (deprecated - to be reconsidered)-->
 			<xs:element name="TimelineComplexity" minOccurs="0" maxOccurs="2">
 				<xs:complexType>
 					<xs:sequence>
@@ -150,26 +152,10 @@
 		</xs:attribute>
 	</xs:complexType>
 	<!-- - -->
-	<!-- Abstract base class containing all common properties for a SingleVirtualTrack -->
-	<xs:complexType name="SingleVirtualTrackType" abstract="true">
-		<xs:complexContent>
-	<xs:extension base="dsl:GenericVirtualTrackType">	
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- - -->
-	<!-- Abstract base class containing all common properties for a MultipleVirtualTrack -->
-	<xs:complexType name="MultipleVirtualTrackType" abstract="true">
-		<xs:complexContent>
-	<xs:extension base="dsl:GenericVirtualTrackType">	
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-	<!-- - -->
-	<!-- AudioVirtualTrack extends the MultipleVirtualTrack-->
+	<!-- AudioVirtualTrack extends the GenericVirtualTrackType-->
 	<xs:complexType name="AudioVirtualTrackType">
 		<xs:complexContent>
-			<xs:extension base="dsl:MultipleVirtualTrackType">
+			<xs:extension base="dsl:GenericVirtualTrackType">
 				<xs:sequence>
 					<xs:element name="SoundfieldGroupConfiguration" minOccurs="0">
 						<xs:complexType>
@@ -226,7 +212,7 @@
 	<!-- ImageVirtualTrack extends the SingleVirtualTrack-->
 	<xs:complexType name="ImageVirtualTrackType">
 		<xs:complexContent>
-			<xs:extension base="dsl:SingleVirtualTrackType">
+			<xs:extension base="dsl:GenericVirtualTrackType">
 				<xs:sequence>
 					<xs:element name="Colorimetry" minOccurs="0">
 						<xs:simpleType>


### PR DESCRIPTION
Updated delivery schema:
- Namespace updated to http://www.imfug.com/ns/delivery-schema/2019
- Inheritance based Virtual Track definition for dsl:ImageVirtualTrackType and dsl:AudioVirtualTrackType
- Image Virtual track constrained to maxOccurs=1
- Pattern constraints added for several elements
- SegmentCardinality on the CPL level introduced
- Netflix example updated accordingly