### PR TITLE
Language tag constraints added, ReferenceCardinality removed, example updated

### DIFF
--- a/examples/Subtitle_And_Marker_VirtualTrack/IMF_DeliverySchema_Marker_Subtitle.xml
+++ b/examples/Subtitle_And_Marker_VirtualTrack/IMF_DeliverySchema_Marker_Subtitle.xml
@@ -97,6 +97,7 @@
                         <SampleRateList>
                             <SampleRate>48000 1</SampleRate>
                         </SampleRateList>
+                        <RFC5646SpokenLanguage>de-DE</RFC5646SpokenLanguage>
                     </AudioVirtualTrack>
                     <AudioVirtualTrack>
                         <TimelineComplexity type="explicit">
@@ -140,10 +141,13 @@
                         <SampleRateList>
                             <SampleRate>48000 1</SampleRate>
                         </SampleRateList>
+                        <RFC5646SpokenLanguage>de-DE</RFC5646SpokenLanguage>
                     </AudioVirtualTrack>
                     <TimedTextVirtualTrack>
                         <TimedTextSequenceType>SubtitlesSequence</TimedTextSequenceType>
                         <NamespaceURI>http://www.w3.org/ns/ttml/profile/imsc1/text</NamespaceURI>
+                        <!-- The RFC5646LanguageTagList value is meant to illustrate allowed values  -->
+                        <RFC5646LanguageTagList>de-DE,en,es-419</RFC5646LanguageTagList>
                     </TimedTextVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>

--- a/examples/Subtitle_And_Marker_VirtualTrack/IMF_DeliverySchema_Marker_Subtitle.xml
+++ b/examples/Subtitle_And_Marker_VirtualTrack/IMF_DeliverySchema_Marker_Subtitle.xml
@@ -146,8 +146,18 @@
                     <TimedTextVirtualTrack>
                         <TimedTextSequenceType>SubtitlesSequence</TimedTextSequenceType>
                         <NamespaceURI>http://www.w3.org/ns/ttml/profile/imsc1/text</NamespaceURI>
-                        <!-- The RFC5646LanguageTagList value is meant to illustrate allowed values  -->
-                        <RFC5646LanguageTagList>de-DE,en,es-419</RFC5646LanguageTagList>
+                        <RFC5646LanguageTagListConstraints>
+                            <!-- Option 1: Explicitely specify a list of language tags to be present in RFC5646LanguageTagList -->
+                            <RFC5646LanguageTagList>de-DE,en,es-419</RFC5646LanguageTagList>
+                        </RFC5646LanguageTagListConstraints>
+                    </TimedTextVirtualTrack>
+                    <TimedTextVirtualTrack>
+                        <TimedTextSequenceType>SubtitlesSequence</TimedTextSequenceType>
+                        <NamespaceURI>http://www.w3.org/ns/ttml/profile/imsc1/text</NamespaceURI>
+                        <RFC5646LanguageTagListConstraints>
+                            <!-- Option 2: SpecifyRFC5646LanguageTagList has to be present  -->
+                            <RFC5646LanguageTagListPresent>true</RFC5646LanguageTagListPresent>
+                        </RFC5646LanguageTagListConstraints>
                     </TimedTextVirtualTrack>
                 </VirtualTrackList>
             </CompositionPlaylistConstraints>

--- a/schema/IMF_DeliverySchema.xsd
+++ b/schema/IMF_DeliverySchema.xsd
@@ -138,13 +138,6 @@
                     </xs:attribute>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="ReferenceCardinality" minOccurs="0">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="Sequence" type="dsl:CardinalityType"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
         </xs:sequence>
         <xs:attribute name="namespace">
             <xs:simpleType>
@@ -211,6 +204,14 @@
                                 </xs:element>
                             </xs:sequence>
                         </xs:complexType>
+                    </xs:element>
+                    <xs:element name="RFC5646SpokenLanguage" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <!-- The pattern restricts the language tag to consist of either a language or a language and a region, as defined in RFC 5646 -->
+                                <xs:pattern value="[a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}"/>
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:element>
                 </xs:sequence>
             </xs:extension>
@@ -369,6 +370,14 @@
                         <xs:simpleType>
                             <xs:restriction base="xs:anyURI">
                                 <xs:pattern value="http://www.w3.org/ns/ttml/profile/imsc1/text|http://www.w3.org/ns/ttml/profile/imsc1/image"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="RFC5646LanguageTagList" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <!-- The pattern constrains the language tags to consist of either a language or a language and a region, as defined in RFC 5646 -->
+                                <xs:pattern value="([a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1},)*[a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:element>

--- a/schema/IMF_DeliverySchema.xsd
+++ b/schema/IMF_DeliverySchema.xsd
@@ -373,17 +373,27 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:element>
-                    <xs:element name="RFC5646LanguageTagList" minOccurs="0">
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <!-- The pattern constrains the language tags to consist of either a language or a language and a region, as defined in RFC 5646 -->
-                                <xs:pattern value="([a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1},)*[a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}"/>
-                            </xs:restriction>
-                        </xs:simpleType>
+                    <xs:element name="RFC5646LanguageTagListConstraints" type="dsl:RFC5646LanguageTagListConstraintsType" minOccurs="0">
                     </xs:element>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+<!-- - -->
+   <xs:complexType name="RFC5646LanguageTagListConstraintsType">
+       <xs:sequence>
+           <xs:choice>
+               <xs:element name="RFC5646LanguageTagList" type="dsl:RFC5646LanguageTagListType"/>
+               <xs:element name="RFC5646LanguageTagListPresent" type="xs:boolean"/>
+           </xs:choice>
+       </xs:sequence>
+   </xs:complexType>
+<!-- - -->
+   <xs:simpleType name="RFC5646LanguageTagListType">
+       <xs:restriction base="xs:string">
+           <!-- The pattern constrains the language tags to consist of either a language or a language and a region, as defined in RFC 5646 -->
+           <xs:pattern value="([a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1},)*[a-zA-Z]{2}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}"/>
+       </xs:restriction>
+   </xs:simpleType>
 <!-- - -->
 </xs:schema>


### PR DESCRIPTION
`<RFC5646SpokenLanguage>` (Audio Virtual Track) and `<RFC5646LanguageTagList>` (Timed Text Virtual Track) constraints added, `ReferenceCardinality` removed.

**Note 1:**
`RFC5646SpokenLanguage` is mandatory per ST 2067-2, if the soundfield group is associated with a primary spoken language.

Therefore, a simple element for specifying the expected language tag has been implemented.

**Note 2:**
`RFC5646LanguageTagList` is optional for Timed Text files.
Therefore, a (mutually exclusive) choice between two constraints has been implemented, examples given below:

                        <RFC5646LanguageTagListConstraints>
                            <!-- Option 1: Explicitely specify a list of language tags to be present in RFC5646LanguageTagList -->
                            <RFC5646LanguageTagList>de-DE,en,es-419</RFC5646LanguageTagList>
                        </RFC5646LanguageTagListConstraints>

or

                        <RFC5646LanguageTagListConstraints>
                            <!-- Option 2: SpecifyRFC5646LanguageTagList has to be present  -->
                            <RFC5646LanguageTagListPresent>true</RFC5646LanguageTagListPresent>
                        </RFC5646LanguageTagListConstraints>

**Note 3:**
The pattern allows for language tags consisting of a language (e.g. "de") or a language plus a region, e.g. ("es-419")

Please comment, in case you have conflicting or additional requirements!